### PR TITLE
Enable rendering of matplotlib images

### DIFF
--- a/_episodes/02-cupy.md
+++ b/_episodes/02-cupy.md
@@ -59,6 +59,7 @@ To get a feeling of how the whole image looks like, we can display the top-left 
 
 ~~~
 import pylab as pyl
+%matplotlib inline # Necessary command to render a matplotlib image in a Jupyter notebook.
 
 # Display the image
 # You can zoom in using the menu in the window that will appear


### PR DESCRIPTION
Added the command
`%matplotlib inline` to episode 2. 
Should suffice for the instructor, but the command is necessary every time a notebook is launched to enable the rendering of matplotlib images.
---
