### PR TITLE
Resolves #94: add matplotlib to packages to install

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -28,7 +28,7 @@ cd /path/to/workshop/dir
 python -m virtualenv --prompt gpu-workshop venv
 source venv/bin/activate
 pip install -U pip  # it is good to update pip to the latest version
-pip install cupy-cuda11x numba jupyterlab
+pip install cupy-cuda11x numba jupyterlab matplotlib
 ~~~
 
 **Note:** we are installing the precompiled `cupy` libraries compiled against the latest version of CUDA.  This is always faster to install, but if you want to use a custom CUDA installation, you can `pip install cupy` instead.  Also note, if you also want the cuda compiler `nvcc`, you have to install the CUDA toolkit manually.  However, this is not required to follow the workshop.  More information can be found in the [`cupy` documentation](https://docs.cupy.dev/en/stable/install.html).
@@ -39,7 +39,7 @@ pip install cupy-cuda11x numba jupyterlab
 ~~~bash
 mamba create -n gpu-workshop
 mamba activate gpu-workshop
-mamba install cupy numba jupyterlab
+mamba install cupy numba jupyterlab matplotlib
 ~~~
 If you are using `conda`, you can simply replace `mamba` with `conda` in the commands above.
 


### PR DESCRIPTION
As mentioned in #94 matplotlib is required for some cells. This adds it for both pip and conda install setups

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
